### PR TITLE
fix wrong info in check_for_new_map_button

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,7 +20,7 @@
     refresh_heroes_positions: 3
     
     # [en_US] Time interval to check for new maps
-    # Default value (in minutes): 5 
+    # Default value (in seconds): 5 
     #
     # [pt_BR] Intervalo de tempo para verificar por novos mapas
     # Valor padrão (em segundos): 5


### PR DESCRIPTION
updating info in config.yaml that showed check_for_new_map_button default as minutes when the information is actually in seconds