### PR TITLE
Baús indestrutíveis

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,6 +47,13 @@
     # Valor padrão (em segundos): 1
     interval_between_moviments: 1
 
+    # [en_US] Time interval to refresh page
+    # Default value (in seconds): 1 
+    #
+    # [pt_BR] Intervalo de tempo para atualizar a página
+    # Valor padrão (em minutos): 1
+    check_for_refresh_page: 30
+
   # [en_US] How confident the bot needs to be to click the buttons (values from 0 to 1. 0 is the minimum value, 1 is the maximum value)
   #
   # [pt_BR] O quão confiante o bot precisa estar para clicar nos botões (valores entre 0 e 1. 0 é o valor mínimo, 1 é o valor máximo)

--- a/config.yaml
+++ b/config.yaml
@@ -51,7 +51,7 @@
     # Default value (in seconds): 1 
     #
     # [pt_BR] Intervalo de tempo para atualizar a página
-    # Valor padrão (em minutos): 1
+    # Valor padrão (em minutos): 30
     check_for_refresh_page: 30
 
   # [en_US] How confident the bot needs to be to click the buttons (values from 0 to 1. 0 is the minimum value, 1 is the maximum value)

--- a/index.py
+++ b/index.py
@@ -481,12 +481,18 @@ def main():
     "heroes" : 0,
     "new_map" : 0,
     "check_for_captcha" : 0,
-    "refresh_heroes" : 0
+    "refresh_heroes" : 0,
+    "refresh_page" : 0
     }
     # =========
 
     while True:
         now = time.time()
+
+        if now - last["refresh_page"] > t['check_for_refresh_page'] * 60:
+            logger('Refreshing Page')
+            last["refresh_page"] = now
+            pyautogui.hotkey('ctrl','f5')
 
         if now - last["check_for_captcha"] > addRandomness(t['check_for_captcha'] * 60):
             last["check_for_captcha"] = now
@@ -510,6 +516,7 @@ def main():
         if now - last["refresh_heroes"] > addRandomness( t['refresh_heroes_positions'] * 60):
             last["refresh_heroes"] = now
             refreshHeroesPositions()
+
 
         #clickBtn(teasureHunt)
         logger(None, progress_indicator=True)

--- a/index.py
+++ b/index.py
@@ -482,7 +482,7 @@ def main():
     "new_map" : 0,
     "check_for_captcha" : 0,
     "refresh_heroes" : 0,
-    "refresh_page" : 0
+    "refresh_page" : time.time()
     }
     # =========
 


### PR DESCRIPTION
Devido a um bug do jogo, alguns baús podem ficar indestrutíveis e é preciso atualizar a página para resolver.

Alterei o bot para que ele atualize a página a cada X minutos, sendo esse X definido pela nova configuração `check_for_refresh_page` em `config.yaml`

Por padrão eu coloquei 30 minutos, mas isso pode variar dependendo da sua equipe de heróis.

Sei que o bug está sendo resolvido pelos devs do jogo, então isso é só uma solução temporária que encontrei, não tendo a necessidade de ficar baixando extensões como já vi algumas pessoas fazerem.